### PR TITLE
Update input to allow multiple keypresses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use potatocho::ChipEight;
 use rfd::FileDialog;
 
+// This function is lifted entirely from the rust-sdl2 github page https://github.com/Rust-SDL2/rust-sdl2
 fn find_sdl_gl_driver() -> Option<u32> {
     for (i, item) in sdl2::render::drivers().enumerate() {
         if item.name == "opengl" {


### PR DESCRIPTION
Rather than just getting the keycode for the last key pressed, we instead use a HashSet to store the keycodes for all currently held keys and remove them once a KeyUp event is detected. This (obviously) allows multiple keys to be held and detected at once.